### PR TITLE
FAI-103: UI component to display PMML Linear Regression models

### DIFF
--- a/front-end-poc-pmml-linear-model-viewer/src/LinearRegressionView.tsx
+++ b/front-end-poc-pmml-linear-model-viewer/src/LinearRegressionView.tsx
@@ -75,11 +75,6 @@ class LinearRegressionView extends React.Component<Props, State> {
             legendData.push({ name: line.title });
         });
 
-        const minDomainX: number = this.props.rangeX.min;
-        const maxDomainX: number = this.props.rangeX.max;
-        const minDomainY: number = this.props.rangeY.min;
-        const maxDomainY: number = this.props.rangeY.max;
-
         return (
             <div style={{ height: height, width: width }}>
                 <Chart
@@ -115,6 +110,7 @@ class LinearRegressionView extends React.Component<Props, State> {
                     <ChartGroup>
                         {this.props.lines.map((line) => {
                             return <ChartLine
+                                key={line.title}
                                 samples={100}
                                 domain={{
                                     x: [

--- a/front-end-poc-pmml-linear-model-viewer/src/LinearRegressionViewAdaptor.tsx
+++ b/front-end-poc-pmml-linear-model-viewer/src/LinearRegressionViewAdaptor.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import * as PMML from "./generated/www.dmg.org/PMML-4_4";
-import { Line, LinearRegressionView } from './LinearRegressionView';
+import { Line, Range, LinearRegressionView } from './LinearRegressionView';
+import { monitorEventLoopDelay } from 'perf_hooks';
 
 type Props = {
   dictionary: PMML.DataDictionaryType
@@ -16,7 +17,7 @@ class LinearRegressionViewAdaptor extends React.Component<Props, State> {
   }
 
   render() {
-    const model: PMML.RegressionModelType | undefined = this.getRegressionModel();
+    const model: PMML.RegressionModelType | undefined = this.getLinearRegressionModel();
     if (model === undefined) {
       return (
         <div>Unsupported</div>
@@ -30,53 +31,27 @@ class LinearRegressionViewAdaptor extends React.Component<Props, State> {
       );
     }
 
-    const modelName: string = model.modelName;
-    const c: number = table.intercept;
+    const numbericPredictor: PMML.NumericPredictorType | undefined = this.getNumericPredictorType(table);
+    if (numbericPredictor === undefined) {
+      return (
+        <div>Unsupported</div>
+      );
+    }
 
+    const modelName: string = model.modelName;
     const miningSchema: PMML.MiningSchemaType = model.MiningSchema;
     const dependentAxisTitle = miningSchema.MiningField.filter(mf => mf.usageType === "target")[0].name;
+    const lines: Line[] = this.getLines(table, numbericPredictor);
 
-    //We can only handle one NumericPredictor
-    const numbericPredictors: PMML.NumericPredictorType[] | undefined = table.NumericPredictor;
-    if (numbericPredictors === undefined) {
-      return (
-        <div>No NumericPredictorType</div>
-      );
+    //Get Ranges from DataDictionary or use reasonable defaults
+    let rangeY: Range | undefined = this.getYRange(model);
+    if (rangeY === undefined) {
+      rangeY = this.getDefaultYRange(lines);
     }
-    if (numbericPredictors.length > 1) {
-      return (
-        <div>Too many NumericPredictorTypes</div>
-      );
+    let rangeX: Range | undefined = this.getXRange(numbericPredictor);
+    if (rangeX === undefined) {
+      rangeX = this.getDefaultXRange(lines, rangeY);
     }
-
-    const numbericPredictor: PMML.NumericPredictorType = numbericPredictors[0];
-    const line: Line = { m: numbericPredictor.coefficient, c: c, title: "base" };
-    const lines: Line[] = new Array<Line>(line);
-
-    //We need to duplicate the line for each CategoricalPredictor
-    const categoricalPredictors: PMML.CategoricalPredictorType[] | undefined = table.CategoricalPredictor;
-    if (categoricalPredictors !== undefined) {
-      categoricalPredictors.forEach(cp => {
-        //cxml returns an array of CategoricalPredictorType with one element even if none are defined in the XML.
-        //This is a hack to check the coefficient is defined and is a number to filter the rogue elements.
-        if (!isNaN(cp.coefficient)) {
-          lines.push({ m: line.m, c: line.c + cp.coefficient, title: line.title + " (" + cp.value + ")" });
-        }
-      });
-    }
-
-    const legendData: any = [];
-    lines.forEach(line => {
-      legendData.push({ name: line.title });
-    });
-
-    const maxIntersect: number = Math.max(...lines.map(line => line.c));
-    const maxDomainY: number = maxIntersect * 2;
-    const minDomainY: number = -maxDomainY;
-
-    const minGradient: number = Math.min(...lines.map(line => line.m));
-    const maxDomainX: number = (maxDomainY - maxIntersect) / minGradient;
-    const minDomainX: number = -maxDomainX;
 
     return (
       <div>
@@ -84,19 +59,23 @@ class LinearRegressionViewAdaptor extends React.Component<Props, State> {
           independentAxisTitle={numbericPredictor.name}
           dependentAxisTitle={dependentAxisTitle}
           lines={lines}
-          rangeX={{ min: minDomainX, max: maxDomainX }}
-          rangeY={{ min: minDomainY, max: maxDomainY }}
+          rangeX={rangeX}
+          rangeY={rangeY}
         />
       </div>
     );
   }
 
-  private getRegressionModel(): PMML.RegressionModelType | undefined {
+  private getLinearRegressionModel(): PMML.RegressionModelType | undefined {
     const models: PMML.RegressionModelType[] = this.props.model;
     if (models === undefined || models.length > 1) {
       return undefined;
     }
-    return models[0];
+    const model: PMML.RegressionModelType = models[0];
+    if (model.functionName === "regression" && model.algorithmName === "linearRegression") {
+      return model;
+    }
+    return undefined;
   }
 
   private getRegressionTable(model: PMML.RegressionModelType): PMML.RegressionTableType | undefined {
@@ -105,6 +84,99 @@ class LinearRegressionViewAdaptor extends React.Component<Props, State> {
       return undefined;
     }
     return tables[0];
+  }
+
+  private getNumericPredictorType(table: PMML.RegressionTableType): PMML.NumericPredictorType | undefined {
+    const predicators: PMML.NumericPredictorType[] | undefined = table.NumericPredictor;
+    if (predicators === undefined || predicators.length > 1) {
+      return undefined;
+    }
+    return predicators[0];
+  }
+
+  private getLines(table: PMML.RegressionTableType, numbericPredictor: PMML.NumericPredictorType): Line[] {
+    const c: number = table.intercept;
+    const line: Line = { m: numbericPredictor.coefficient, c: c, title: "base" };
+    const lines: Line[] = new Array<Line>(line);
+
+    //We need to duplicate the line for each CategoricalPredictor
+    const categoricalPredictors: PMML.CategoricalPredictorType[] | undefined = table.CategoricalPredictor;
+    if (categoricalPredictors === undefined) {
+      return lines;
+    }
+    //cxml returns an array of CategoricalPredictorType with one element even if none are defined in the XML.
+    //This is a hack to check the array does not contain the rogue element.
+    if (categoricalPredictors.length == 1 && categoricalPredictors[0]._exists === false) {
+      return lines;
+    }
+    categoricalPredictors.forEach(cp => {
+      lines.push({ m: line.m, c: line.c + cp.coefficient, title: line.title + " (" + cp.value + ")" });
+    });
+
+    return lines;
+  }
+
+  private getYRange(model: PMML.RegressionModelType): Range | undefined {
+    const targetField: PMML.MiningFieldType | undefined = this.getTargetMiningField(model);
+    if (targetField === undefined) {
+      return undefined;
+    }
+    const targetFieldIntervals: PMML.IntervalType[] | undefined = this.getMiningFieldIntervals(targetField.name);
+    return this.getIntervalsMaximumRange(targetFieldIntervals);
+  }
+
+  private getTargetMiningField(model: PMML.RegressionModelType): PMML.MiningFieldType | undefined {
+    const targetFields: PMML.MiningFieldType[] = model.MiningSchema.MiningField.filter(mf => mf.usageType === "target");
+    if (targetFields === undefined || targetFields.length != 1) {
+      return undefined;
+    }
+    return targetFields[0];
+  }
+
+  private getXRange(numbericPredictor: PMML.NumericPredictorType): Range | undefined {
+    const predictorFieldIntervals: PMML.IntervalType[] | undefined = this.getMiningFieldIntervals(numbericPredictor.name);
+    return this.getIntervalsMaximumRange(predictorFieldIntervals);
+  }
+
+  private getMiningFieldIntervals(fieldName: string): PMML.IntervalType[] | undefined {
+    const dataFields: PMML.DataFieldType[] = this.props.dictionary.DataField.filter(df => df.name === fieldName && df.optype === "continuous");
+    if (dataFields === undefined || dataFields.length != 1) {
+      return undefined;
+    }
+    const intervals: PMML.IntervalType[] | undefined = dataFields[0].Interval;
+    if (intervals === undefined) {
+      return undefined;
+    }
+    //cxml returns an array of IntervalType with one element even if none are defined in the XML.
+    //This is a hack to check the array does not contain the rogue element.
+    if (intervals.length === 1 && intervals[0]._exists === false) {
+      return undefined;
+    }
+    return intervals;
+  }
+
+  private getIntervalsMaximumRange(intervals: PMML.IntervalType[] | undefined): Range | undefined {
+    if (intervals === undefined) {
+      return undefined;
+    }
+    const min: number = intervals.map(interval => interval.leftMargin).reduce((pv, cv) => Math.min(pv, cv));
+    const max: number = intervals.map(interval => interval.rightMargin).reduce((pv, cv) => Math.max(pv, cv));
+    return new Range(min, max);
+  }
+
+  private getDefaultYRange(lines: Line[]): Range {
+    const maxIntersect: number = Math.max(...lines.map(line => line.c));
+    const defaultMaxY: number = maxIntersect * 2;
+    const defaultMinY: number = -defaultMaxY;
+    return new Range(defaultMinY, defaultMaxY);
+  }
+
+  private getDefaultXRange(lines: Line[], rangeY: Range): Range {
+    const minGradient: number = Math.min(...lines.map(line => line.m));
+    const maxIntersect: number = Math.max(...lines.map(line => line.c));
+    const defaultMaxX: number = (rangeY.max - maxIntersect) / minGradient;
+    const defaultMinX: number = -defaultMaxX;
+    return new Range(defaultMinX, defaultMaxX);
   }
 
 }

--- a/front-end-poc-pmml-linear-model-viewer/src/LinearRegressionViewAdaptor.tsx
+++ b/front-end-poc-pmml-linear-model-viewer/src/LinearRegressionViewAdaptor.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import * as PMML from "./generated/www.dmg.org/PMML-4_4";
-import { Line, Range, LinearRegressionView } from './LinearRegressionView';
-import { monitorEventLoopDelay } from 'perf_hooks';
+import { Line, LinearRegressionView, Range } from './LinearRegressionView';
 
 type Props = {
   dictionary: PMML.DataDictionaryType
@@ -182,3 +181,4 @@ class LinearRegressionViewAdaptor extends React.Component<Props, State> {
 }
 
 export { LinearRegressionViewAdaptor };
+

--- a/front-end-poc-pmml-linear-model-viewer/src/index.tsx
+++ b/front-end-poc-pmml-linear-model-viewer/src/index.tsx
@@ -1,4 +1,4 @@
-import { example1 } from "./example";
+import { example1, example2, example3 } from "./resources/examples";
 import { LinearRegressionViewer } from "./LinearRegressionViewer";
 
-export { example1, LinearRegressionViewer };
+export { example1, example2, example3, LinearRegressionViewer };

--- a/front-end-poc-pmml-linear-model-viewer/src/resources/examples.ts
+++ b/front-end-poc-pmml-linear-model-viewer/src/resources/examples.ts
@@ -53,8 +53,12 @@ const example2: string = "<PMML xmlns='http://www.dmg.org/PMML-4_4' version='4.4
 const example3: string = "<PMML xmlns='http://www.dmg.org/PMML-4_4' version='4.4'> " +
   "<Header copyright='DMG.org'/>" +
   "<DataDictionary numberOfFields='2'>" +
-  "  <DataField name='age' optype='continuous' dataType='double'/>" +
-  "  <DataField name='weight' optype='continuous' dataType='double'/>" +
+  "  <DataField name='age' optype='continuous' dataType='double'>" +
+  "    <Interval closure='closedClosed' leftMargin='0' rightMargin='100'/>" +
+  "  </DataField>" +
+  "  <DataField name='weight' optype='continuous' dataType='double'>" +
+  "    <Interval closure='closedClosed' leftMargin='0' rightMargin='200'/>" +
+  "  </DataField>" +
   "</DataDictionary>" +
   "<RegressionModel modelName='You get fatter as you get older' functionName='regression' algorithmName='linearRegression' targetFieldName='height_of_tide'>" +
   "  <MiningSchema>" +

--- a/front-end-poc/src/ModelLookup/ModelDiagram.tsx
+++ b/front-end-poc/src/ModelLookup/ModelDiagram.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { IModelVersion } from "./types"
-import { LinearRegressionViewer, example1 } from "@manstis/pmml-linear-model-viewer"
+import { LinearRegressionViewer, example3 } from "@manstis/pmml-linear-model-viewer"
 
 const ModelDiagram = (props: { selectedVersion: IModelVersion }) => {
   const { selectedVersion } = props;
@@ -14,7 +14,7 @@ const ModelDiagram = (props: { selectedVersion: IModelVersion }) => {
   return (
     <div className="model-diagram">
       <div className="model-diagram__iframe" dangerouslySetInnerHTML={kogitoIframe()} />
-      <LinearRegressionViewer xml={example1} />
+      <LinearRegressionViewer xml={example3} />
     </div>
   );
 };


### PR DESCRIPTION
This improves the viewer for Linear Regression Models:-
- Code tidy-up
- Use `Intervals` from the `DataDictionary` to determine the chart range.

@danielezonca If there are multiple `Interval` defined for a _continuous_ `DataField` (see [here](http://dmg.org/pmml/v4-4/DataDictionary.html#xsdElement_Interval), "A continuous field may have an unlimited number of intervals defining the range of valid values") I show the maximum extents of them all; e.g. given two `Interval` with one defined as `leftMargin=0`, `rightMargin=100` and the other `leftMargin=200`, `rightMargin=400` I'd show a range of `[0..400]`. I think that's good enough for now without complicating the chart. WDYT?

I plan on using this viewer as driver for changes to `kogito-tooling` etc to be able to re-use it in VSCode, Github, Elektron and now Trusty. I didn't really want to focus much more on its capabilities (e.g. how does a user provide the range to view - as you've previously suggested) without UX involvement and a new JIRA.

![Screenshot from 2020-04-21 22-08-12](https://user-images.githubusercontent.com/497544/79914870-e2ab0c00-841d-11ea-984a-d2e91e2e423a.png)

(^ This isn't a linear regression.. but it feels like it at 47! I can refactor when I'm 87). 