### PR TITLE
FAI-131: Agree and document model (XML) endpoint API

### DIFF
--- a/front-end-poc/api-mock/mocks/modelData.js
+++ b/front-end-poc/api-mock/mocks/modelData.js
@@ -74,53 +74,143 @@ const example3 = "<PMML xmlns='http://www.dmg.org/PMML-4_4' version='4.4'> " +
 const modelData = [
     {
         executionId: 1000,
-        modelType: "DMN",
-        xml: ""
+        deploymentDate: "01012020",
+        modelId: "1234567890",
+        name: "modelName",
+        namespace: "modelNameSpace",
+        type: "http://www.omg.org/spec/DMN/20151101/dmn.xsd",
+        serviceIdentifier: {
+            groupId: "groupId",
+            artifactId: "artifacrtId",
+            version: "version"
+        },
+        model: ""
     },
     {
         executionId: 1001,
-        modelType: "DMN",
-        xml: ""
+        deploymentDate: "01012020",
+        modelId: "1234567890",
+        name: "modelName",
+        namespace: "modelNameSpace",
+        type: "http://www.omg.org/spec/DMN/20151101/dmn.xsd",
+        serviceIdentifier: {
+            groupId: "groupId",
+            artifactId: "artifacrtId",
+            version: "version"
+        },
+        model: ""
     },
     {
         executionId: 1002,
-        modelType: "DMN",
-        xml: ""
+        deploymentDate: "01012020",
+        modelId: "1234567890",
+        name: "modelName",
+        namespace: "modelNameSpace",
+        type: "http://www.omg.org/spec/DMN/20151101/dmn.xsd",
+        serviceIdentifier: {
+            groupId: "groupId",
+            artifactId: "artifacrtId",
+            version: "version"
+        },
+        model: ""
     },
     {
         executionId: 1003,
-        modelType: "DMN",
-        xml: ""
+        deploymentDate: "01012020",
+        modelId: "1234567890",
+        name: "modelName",
+        namespace: "modelNameSpace",
+        type: "http://www.omg.org/spec/DMN/20151101/dmn.xsd",
+        serviceIdentifier: {
+            groupId: "groupId",
+            artifactId: "artifacrtId",
+            version: "version"
+        },
+        model: ""
     },
     {
         executionId: 1004,
-        modelType: "DMN",
-        xml: ""
+        deploymentDate: "01012020",
+        modelId: "1234567890",
+        name: "modelName",
+        namespace: "modelNameSpace",
+        type: "http://www.omg.org/spec/DMN/20151101/dmn.xsd",
+        serviceIdentifier: {
+            groupId: "groupId",
+            artifactId: "artifacrtId",
+            version: "version"
+        },
+        model: ""
     },
     {
         executionId: 1005,
-        modelType: "PMML",
-        xml: example1
+        deploymentDate: "01012020",
+        modelId: "1234567890",
+        name: "modelName",
+        namespace: "modelNameSpace",
+        type: "http://www.dmg.org/PMML-4_4",
+        serviceIdentifier: {
+            groupId: "groupId",
+            artifactId: "artifacrtId",
+            version: "version"
+        },
+        model: example1
     },
     {
         executionId: 1006,
-        modelType: "PMML",
-        xml: example2
+        deploymentDate: "01012020",
+        modelId: "1234567890",
+        name: "modelName",
+        namespace: "modelNameSpace",
+        type: "http://www.dmg.org/PMML-4_4",
+        serviceIdentifier: {
+            groupId: "groupId",
+            artifactId: "artifacrtId",
+            version: "version"
+        },
+        model: example2
     },
     {
         executionId: 1007,
-        modelType: "PMML",
-        xml: example3
+        deploymentDate: "01012020",
+        modelId: "1234567890",
+        name: "modelName",
+        namespace: "modelNameSpace",
+        type: "http://www.dmg.org/PMML-4_4",
+        serviceIdentifier: {
+            groupId: "groupId",
+            artifactId: "artifacrtId",
+            version: "version"
+        },
+        model: example3
     },
     {
         executionId: 1008,
-        modelType: "PMML",
-        xml: example1
+        deploymentDate: "01012020",
+        modelId: "1234567890",
+        name: "modelName",
+        namespace: "modelNameSpace",
+        type: "http://www.dmg.org/PMML-4_4",
+        serviceIdentifier: {
+            groupId: "groupId",
+            artifactId: "artifacrtId",
+            version: "version"
+        },
+        model: example1
     },
     {
         executionId: 1009,
-        modelType: "PMML",
-        xml: example2
+        deploymentDate: "01012020",
+        modelId: "1234567890",
+        name: "modelName",
+        namespace: "modelNameSpace",
+        type: "http://www.dmg.org/PMML-4_4",
+        serviceIdentifier: {
+            groupId: "groupId",
+            artifactId: "artifacrtId",
+            version: "version"
+        },
+        model: example2
     }
 ];
 

--- a/front-end-poc/api-mock/routes.json
+++ b/front-end-poc/api-mock/routes.json
@@ -4,5 +4,5 @@
   "/executions/:executionType/:executionId/featureImportance": "/featureImportance?executionId=:executionId",
   "/executions/:executionType/:executionId/outcomes": "/outcomes?executionId=:executionId",
   "/executions/:executionType/:executionId/outcomes/:outcomeId": "/outcomeDetail?executionId=:executionId&outcomeId=:outcomeId",
-  "/models/:executionId": "/models?executionId=:executionId"
+  "/executions/:executionType/:executionId/model": "/models?executionId=:executionId"
 }

--- a/front-end-poc/src/Audit/types.ts
+++ b/front-end-poc/src/Audit/types.ts
@@ -20,7 +20,7 @@ export interface IExecutionRouteParams {
     executionType: ExecutionType
 }
 
-export interface IFullModelResponse {
+export interface IExecutionModelResponse {
     deploymentDate?: string,
     modelId?: string,
     name: string,

--- a/front-end-poc/src/Audit/types.ts
+++ b/front-end-poc/src/Audit/types.ts
@@ -21,16 +21,15 @@ export interface IExecutionRouteParams {
 }
 
 export interface IFullModelResponse {
-    executionId: number,
-    deploymentDate: string,
-    modelId: string,
+    deploymentDate?: string,
+    modelId?: string,
     name: string,
     namespace: string,
     type: string,
     serviceIdentifier: {
-        groupId: string,
-        artifactId: string,
-        version: string
+        groupId?: string,
+        artifactId?: string,
+        version?: string
     },
     model: string
 }

--- a/front-end-poc/src/Audit/types.ts
+++ b/front-end-poc/src/Audit/types.ts
@@ -19,3 +19,18 @@ export interface IExecutionRouteParams {
     executionId: string,
     executionType: ExecutionType
 }
+
+export interface IFullModelResponse {
+    executionId: number,
+    deploymentDate: string,
+    modelId: string,
+    name: string,
+    namespace: string,
+    type: string,
+    serviceIdentifier: {
+        groupId: string,
+        artifactId: string,
+        version: string
+    },
+    model: string
+}

--- a/front-end-poc/src/ModelLookup/ModelDiagram.tsx
+++ b/front-end-poc/src/ModelLookup/ModelDiagram.tsx
@@ -1,19 +1,19 @@
 import React from 'react';
-import { IFullModelResponse } from "../Audit/types";
+import { IExecutionModelResponse } from "../Audit/types";
 import { LinearRegressionViewer } from "./pmml/LinearRegressionViewer";
 
 const DMN1_2: string = "http://www.omg.org/spec/DMN/20151101/dmn.xsd";
 const PMML4_4: string = "http://www.dmg.org/PMML-4_4";
 
 interface Props {
-  model: IFullModelResponse;
+  model: IExecutionModelResponse;
 }
 
 function makeUnknownModel(): JSX.Element {
   return <div>Unknown model type</div>
 }
 
-function makeDMNEditor(model: IFullModelResponse): JSX.Element {
+function makeDMNEditor(model: IExecutionModelResponse): JSX.Element {
   const model1Url: string = "https://raw.githubusercontent.com/kiegroup/kogito-tooling/master/packages/online-editor/static/samples/sample.dmn#/editor/dmn";
   const model2Url: string = "https://gist.githubusercontent.com/r00ta/c5077ac1f12746e356e1d4f03620ee05/raw/a3d2a865398547a18010e78dd4c1b0d76cc85d99/myMortgage.dmn";
   const editorUrl = `https://kiegroup.github.io/kogito-online/?file=${model1Url}`;
@@ -23,7 +23,7 @@ function makeDMNEditor(model: IFullModelResponse): JSX.Element {
   return <div className="model-diagram__iframe" dangerouslySetInnerHTML={kogitoIframe()} />;
 }
 
-function makePMMLEditor(model: IFullModelResponse): JSX.Element {
+function makePMMLEditor(model: IExecutionModelResponse): JSX.Element {
   return <LinearRegressionViewer xml={model.model} />;
 }
 

--- a/front-end-poc/src/ModelLookup/ModelDiagram.tsx
+++ b/front-end-poc/src/ModelLookup/ModelDiagram.tsx
@@ -14,9 +14,8 @@ function makeUnknownModel(): JSX.Element {
 }
 
 function makeDMNEditor(model: IExecutionModelResponse): JSX.Element {
-  const model1Url: string = "https://raw.githubusercontent.com/kiegroup/kogito-tooling/master/packages/online-editor/static/samples/sample.dmn#/editor/dmn";
-  const model2Url: string = "https://gist.githubusercontent.com/r00ta/c5077ac1f12746e356e1d4f03620ee05/raw/a3d2a865398547a18010e78dd4c1b0d76cc85d99/myMortgage.dmn";
-  const editorUrl = `https://kiegroup.github.io/kogito-online/?file=${model1Url}`;
+  const modelUrl: string = "https://raw.githubusercontent.com/kiegroup/kogito-tooling/master/packages/online-editor/static/samples/sample.dmn#/editor/dmn";
+  const editorUrl = `https://kiegroup.github.io/kogito-online/?file=${modelUrl}`;
   const kogitoIframe = () => {
     return { __html: `<iframe src=${editorUrl}"></iframe>` };
   };

--- a/front-end-poc/src/ModelLookup/ModelDiagram.tsx
+++ b/front-end-poc/src/ModelLookup/ModelDiagram.tsx
@@ -13,37 +13,32 @@ function makeUnknownModel(): JSX.Element {
   return <div>Unknown model type</div>
 }
 
-function makeDMNEditor(executionId: number): JSX.Element {
+function makeDMNEditor(model: IFullModelResponse): JSX.Element {
   const model1Url: string = "https://raw.githubusercontent.com/kiegroup/kogito-tooling/master/packages/online-editor/static/samples/sample.dmn#/editor/dmn";
   const model2Url: string = "https://gist.githubusercontent.com/r00ta/c5077ac1f12746e356e1d4f03620ee05/raw/a3d2a865398547a18010e78dd4c1b0d76cc85d99/myMortgage.dmn";
   const editorUrl = `https://kiegroup.github.io/kogito-online/?file=${model1Url}`;
   const kogitoIframe = () => {
-    return { __html: `<iframe src=${editorUrl} data-key="${executionId}"></iframe>` };
+    return { __html: `<iframe src=${editorUrl}"></iframe>` };
   };
   return <div className="model-diagram__iframe" dangerouslySetInnerHTML={kogitoIframe()} />;
 }
 
-function makePMMLEditor(xml: string): JSX.Element {
-  return <LinearRegressionViewer xml={xml} />;
+function makePMMLEditor(model: IFullModelResponse): JSX.Element {
+  return <LinearRegressionViewer xml={model.model} />;
 }
 
 const DEFAULT: JSX.Element = makeUnknownModel();
 
 const ModelDiagram = (props: Props) => {
 
-  const { executionId, type, model } = props.model;
+  const { model } = props;
+  const type: string = model.type;
 
   switch (type) {
     case DMN1_2:
-      if (executionId !== undefined) {
-        return makeDMNEditor(executionId);
-      }
-      break;
+      return makeDMNEditor(model);
     case PMML4_4:
-      if (model !== undefined) {
-        return makePMMLEditor(model);
-      }
-      break;
+      return makePMMLEditor(model);
   }
 
   return DEFAULT;

--- a/front-end-poc/src/ModelLookup/ModelDiagram.tsx
+++ b/front-end-poc/src/ModelLookup/ModelDiagram.tsx
@@ -1,18 +1,22 @@
 import React from 'react';
+import { IFullModelResponse } from "../Audit/types";
 import { LinearRegressionViewer } from "./pmml/LinearRegressionViewer";
 
+const DMN1_2: string = "http://www.omg.org/spec/DMN/20151101/dmn.xsd";
+const PMML4_4: string = "http://www.dmg.org/PMML-4_4";
+
 interface Props {
-  executionId?: string;
-  modelType?: string;
-  xml?: string;
+  model: IFullModelResponse;
 }
 
 function makeUnknownModel(): JSX.Element {
   return <div>Unknown model type</div>
 }
 
-function makeDMNEditor(executionId: string): JSX.Element {
-  const editorUrl = "https://kiegroup.github.io/kogito-online/?file=https://raw.githubusercontent.com/kiegroup/kogito-tooling/master/packages/online-editor/static/samples/sample.dmn#/editor/dmn";
+function makeDMNEditor(executionId: number): JSX.Element {
+  const model1Url: string = "https://raw.githubusercontent.com/kiegroup/kogito-tooling/master/packages/online-editor/static/samples/sample.dmn#/editor/dmn";
+  const model2Url: string = "https://gist.githubusercontent.com/r00ta/c5077ac1f12746e356e1d4f03620ee05/raw/a3d2a865398547a18010e78dd4c1b0d76cc85d99/myMortgage.dmn";
+  const editorUrl = `https://kiegroup.github.io/kogito-online/?file=${model1Url}`;
   const kogitoIframe = () => {
     return { __html: `<iframe src=${editorUrl} data-key="${executionId}"></iframe>` };
   };
@@ -27,17 +31,17 @@ const DEFAULT: JSX.Element = makeUnknownModel();
 
 const ModelDiagram = (props: Props) => {
 
-  const { executionId = undefined, modelType = undefined, xml = undefined } = props;
+  const { executionId, type, model } = props.model;
 
-  switch (modelType) {
-    case "DMN":
+  switch (type) {
+    case DMN1_2:
       if (executionId !== undefined) {
-        return makeDMNEditor(executionId as string);
+        return makeDMNEditor(executionId);
       }
       break;
-    case "PMML":
-      if (xml !== undefined) {
-        return makePMMLEditor(xml as string);
+    case PMML4_4:
+      if (model !== undefined) {
+        return makePMMLEditor(model);
       }
       break;
   }

--- a/front-end-poc/src/ModelLookup/ModelLookup.tsx
+++ b/front-end-poc/src/ModelLookup/ModelLookup.tsx
@@ -1,11 +1,10 @@
 import { Divider, PageSection, PageSectionVariants, Spinner } from "@patternfly/react-core";
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useParams } from "react-router-dom";
-import { IExecutionRouteParams } from "../Audit/types";
+import { IExecutionRouteParams, IFullModelResponse } from "../Audit/types";
 import { getModelDetail } from "../Shared/api/audit.api";
 import ModelDiagram from "./ModelDiagram";
 import "./ModelLookup.scss";
-
 
 const ModelLookup = () => {
     const { executionId } = useParams<IExecutionRouteParams>();
@@ -16,10 +15,8 @@ const ModelLookup = () => {
         getModelDetail(executionId)
             .then(response => {
                 if (didMount) {
-                    const modelType: string = response.data[0].modelType;
-                    const xml: string = response.data[0].xml;
-
-                    setViewer(<ModelDiagram executionId={executionId} modelType={modelType} xml={xml} />);
+                    const model: IFullModelResponse = response.data[0] as IFullModelResponse;
+                    setViewer(<ModelDiagram model={model} />);
                 }
             })
             .catch(() => { });

--- a/front-end-poc/src/ModelLookup/ModelLookup.tsx
+++ b/front-end-poc/src/ModelLookup/ModelLookup.tsx
@@ -1,7 +1,7 @@
 import { Divider, PageSection, PageSectionVariants, Spinner } from "@patternfly/react-core";
 import React, { useEffect, useState } from 'react';
 import { useParams } from "react-router-dom";
-import { IExecutionRouteParams, IFullModelResponse } from "../Audit/types";
+import { IExecutionModelResponse, IExecutionRouteParams } from "../Audit/types";
 import { getModelDetail } from "../Shared/api/audit.api";
 import ModelDiagram from "./ModelDiagram";
 import "./ModelLookup.scss";
@@ -15,7 +15,7 @@ const ModelLookup = () => {
         getModelDetail(executionId)
             .then(response => {
                 if (didMount) {
-                    const model: IFullModelResponse = response.data[0] as IFullModelResponse;
+                    const model: IExecutionModelResponse = response.data[0] as IExecutionModelResponse;
                     setViewer(<ModelDiagram model={model} />);
                 }
             })

--- a/front-end-poc/src/Shared/api/audit.api.ts
+++ b/front-end-poc/src/Shared/api/audit.api.ts
@@ -4,7 +4,6 @@ import { AxiosRequestConfig } from "axios";
 const EXECUTIONS_PATH = "/executions";
 const DECISIONS_PATH = EXECUTIONS_PATH + "/decisions";
 const PROCESS_PATH = EXECUTIONS_PATH + "/processes";
-const MODELS_PATH = "/models";
 
 export type ExecutionType = 'decision' | 'process';
 
@@ -70,16 +69,16 @@ const getDecisionFeatureScores = (executionId: string) => {
 }
 
 const getDecisionOutcomeDetail = (executionId: string, outcomeId: string) => {
-    const getDecisionOutcomeDetailConfig : AxiosRequestConfig = {
+    const getDecisionOutcomeDetailConfig: AxiosRequestConfig = {
         url: `${DECISIONS_PATH}/${executionId}/outcomes/${outcomeId}`,
         method: 'get'
     }
     return httpClient(getDecisionOutcomeDetailConfig);
 }
 
-const getModelDetail = (id: string) => {
+const getModelDetail = (executionId: string) => {
     const getModelDetailConfig: AxiosRequestConfig = {
-        url: `${MODELS_PATH}/${id}`,
+        url: `${DECISIONS_PATH}/${executionId}/model`,
         method: 'get'
     }
     return httpClient(getModelDetailConfig);


### PR DESCRIPTION
@r00ta I've emulated how I see `FullModelResponse` should _look_ (given my comment on the JIRA). I've also changed the UI to use the `exectutions/decisions/{executionId}/model` endpoint.. All that remains is for us to align in my UI mock implementation and your end2endPOC implementation.