### PR TITLE
[FAI-133-demo] FAI-131: Agree and document model (XML) endpoint API

### DIFF
--- a/front-end-poc/api-mock/mocks/modelData.js
+++ b/front-end-poc/api-mock/mocks/modelData.js
@@ -74,53 +74,143 @@ const example3 = "<PMML xmlns='http://www.dmg.org/PMML-4_4' version='4.4'> " +
 const modelData = [
     {
         executionId: 1000,
-        modelType: "DMN",
-        xml: ""
+        deploymentDate: "01012020",
+        modelId: "1234567890",
+        name: "modelName",
+        namespace: "modelNameSpace",
+        type: "http://www.omg.org/spec/DMN/20151101/dmn.xsd",
+        serviceIdentifier: {
+            groupId: "groupId",
+            artifactId: "artifacrtId",
+            version: "version"
+        },
+        model: ""
     },
     {
         executionId: 1001,
-        modelType: "DMN",
-        xml: ""
+        deploymentDate: "01012020",
+        modelId: "1234567890",
+        name: "modelName",
+        namespace: "modelNameSpace",
+        type: "http://www.omg.org/spec/DMN/20151101/dmn.xsd",
+        serviceIdentifier: {
+            groupId: "groupId",
+            artifactId: "artifacrtId",
+            version: "version"
+        },
+        model: ""
     },
     {
         executionId: 1002,
-        modelType: "DMN",
-        xml: ""
+        deploymentDate: "01012020",
+        modelId: "1234567890",
+        name: "modelName",
+        namespace: "modelNameSpace",
+        type: "http://www.omg.org/spec/DMN/20151101/dmn.xsd",
+        serviceIdentifier: {
+            groupId: "groupId",
+            artifactId: "artifacrtId",
+            version: "version"
+        },
+        model: ""
     },
     {
         executionId: 1003,
-        modelType: "DMN",
-        xml: ""
+        deploymentDate: "01012020",
+        modelId: "1234567890",
+        name: "modelName",
+        namespace: "modelNameSpace",
+        type: "http://www.omg.org/spec/DMN/20151101/dmn.xsd",
+        serviceIdentifier: {
+            groupId: "groupId",
+            artifactId: "artifacrtId",
+            version: "version"
+        },
+        model: ""
     },
     {
         executionId: 1004,
-        modelType: "DMN",
-        xml: ""
+        deploymentDate: "01012020",
+        modelId: "1234567890",
+        name: "modelName",
+        namespace: "modelNameSpace",
+        type: "http://www.omg.org/spec/DMN/20151101/dmn.xsd",
+        serviceIdentifier: {
+            groupId: "groupId",
+            artifactId: "artifacrtId",
+            version: "version"
+        },
+        model: ""
     },
     {
         executionId: 1005,
-        modelType: "PMML",
-        xml: example1
+        deploymentDate: "01012020",
+        modelId: "1234567890",
+        name: "modelName",
+        namespace: "modelNameSpace",
+        type: "http://www.dmg.org/PMML-4_4",
+        serviceIdentifier: {
+            groupId: "groupId",
+            artifactId: "artifacrtId",
+            version: "version"
+        },
+        model: example1
     },
     {
         executionId: 1006,
-        modelType: "PMML",
-        xml: example2
+        deploymentDate: "01012020",
+        modelId: "1234567890",
+        name: "modelName",
+        namespace: "modelNameSpace",
+        type: "http://www.dmg.org/PMML-4_4",
+        serviceIdentifier: {
+            groupId: "groupId",
+            artifactId: "artifacrtId",
+            version: "version"
+        },
+        model: example2
     },
     {
         executionId: 1007,
-        modelType: "PMML",
-        xml: example3
+        deploymentDate: "01012020",
+        modelId: "1234567890",
+        name: "modelName",
+        namespace: "modelNameSpace",
+        type: "http://www.dmg.org/PMML-4_4",
+        serviceIdentifier: {
+            groupId: "groupId",
+            artifactId: "artifacrtId",
+            version: "version"
+        },
+        model: example3
     },
     {
         executionId: 1008,
-        modelType: "PMML",
-        xml: example1
+        deploymentDate: "01012020",
+        modelId: "1234567890",
+        name: "modelName",
+        namespace: "modelNameSpace",
+        type: "http://www.dmg.org/PMML-4_4",
+        serviceIdentifier: {
+            groupId: "groupId",
+            artifactId: "artifacrtId",
+            version: "version"
+        },
+        model: example1
     },
     {
         executionId: 1009,
-        modelType: "PMML",
-        xml: example2
+        deploymentDate: "01012020",
+        modelId: "1234567890",
+        name: "modelName",
+        namespace: "modelNameSpace",
+        type: "http://www.dmg.org/PMML-4_4",
+        serviceIdentifier: {
+            groupId: "groupId",
+            artifactId: "artifacrtId",
+            version: "version"
+        },
+        model: example2
     }
 ];
 

--- a/front-end-poc/api-mock/mocks/modelData.js
+++ b/front-end-poc/api-mock/mocks/modelData.js
@@ -90,7 +90,7 @@ const modelData = [
         executionId: 1001,
         deploymentDate: "01012020",
         modelId: "1234567890",
-        name: "modelName",
+        name: "fraud-scoring",
         namespace: "modelNameSpace",
         type: "http://www.omg.org/spec/DMN/20151101/dmn.xsd",
         serviceIdentifier: {

--- a/front-end-poc/api-mock/mocks/modelData.js
+++ b/front-end-poc/api-mock/mocks/modelData.js
@@ -76,7 +76,7 @@ const modelData = [
         executionId: 1000,
         deploymentDate: "01012020",
         modelId: "1234567890",
-        name: "modelName",
+        name: "myMortgage",
         namespace: "modelNameSpace",
         type: "http://www.omg.org/spec/DMN/20151101/dmn.xsd",
         serviceIdentifier: {

--- a/front-end-poc/api-mock/routes.json
+++ b/front-end-poc/api-mock/routes.json
@@ -4,5 +4,5 @@
   "/executions/:executionType/:executionId/featureImportance": "/featureImportance?executionId=:executionId",
   "/executions/:executionType/:executionId/outcomes": "/outcomes?executionId=:executionId",
   "/executions/:executionType/:executionId/outcomes/:outcomeId": "/outcomeDetail?executionId=:executionId&outcomeId=:outcomeId",
-  "/models/:executionId": "/models?executionId=:executionId"
+  "/executions/:executionType/:executionId/model": "/models?executionId=:executionId"
 }

--- a/front-end-poc/src/Audit/types.ts
+++ b/front-end-poc/src/Audit/types.ts
@@ -19,3 +19,17 @@ export interface IExecutionRouteParams {
     executionId: string,
     executionType: ExecutionType
 }
+
+export interface IExecutionModelResponse {
+    deploymentDate?: string,
+    modelId?: string,
+    name: string,
+    namespace: string,
+    type: string,
+    serviceIdentifier: {
+        groupId?: string,
+        artifactId?: string,
+        version?: string
+    },
+    model: string
+}

--- a/front-end-poc/src/ModelLookup/ModelDiagram.tsx
+++ b/front-end-poc/src/ModelLookup/ModelDiagram.tsx
@@ -6,9 +6,15 @@ const DMN1_2: string = "http://www.omg.org/spec/DMN/20151101/dmn.xsd";
 const PMML4_4: string = "http://www.dmg.org/PMML-4_4";
 
 const model1Url: string = "https://gist.githubusercontent.com/r00ta/c5077ac1f12746e356e1d4f03620ee05/raw/a3d2a865398547a18010e78dd4c1b0d76cc85d99/myMortgage.dmn";
+const model2Url: string = "https://gist.githubusercontent.com/r00ta/89e8688889a36e16d74789cf3bb92565/raw/ba345e57efef37b4d180dd725cebeb80b5e214b6/fraud.dmn";
 const defaultModelUrl: string = "https://raw.githubusercontent.com/kiegroup/kogito-tooling/master/packages/online-editor/static/samples/sample.dmn";
 
-let models: Map<string, string> = new Map([["myMortgage", model1Url]]);
+const models: Map<string, string> = new Map(
+  [
+    ["myMortgage", model1Url],
+    ["fraud-scoring", model2Url]
+  ]
+);
 
 interface Props {
   model: IExecutionModelResponse;

--- a/front-end-poc/src/ModelLookup/ModelDiagram.tsx
+++ b/front-end-poc/src/ModelLookup/ModelDiagram.tsx
@@ -1,45 +1,43 @@
 import React from 'react';
+import { IExecutionModelResponse } from "../Audit/types";
 import { LinearRegressionViewer } from "./pmml/LinearRegressionViewer";
 
+const DMN1_2: string = "http://www.omg.org/spec/DMN/20151101/dmn.xsd";
+const PMML4_4: string = "http://www.dmg.org/PMML-4_4";
+
 interface Props {
-  executionId?: string;
-  modelType?: string;
-  xml?: string;
+  model: IExecutionModelResponse;
 }
 
 function makeUnknownModel(): JSX.Element {
   return <div>Unknown model type</div>
 }
 
-function makeDMNEditor(executionId: string): JSX.Element {
-  const editorUrl = "https://kiegroup.github.io/kogito-online/?file=https://raw.githubusercontent.com/kiegroup/kogito-tooling/master/packages/online-editor/static/samples/sample.dmn#/editor/dmn";
+function makeDMNEditor(model: IExecutionModelResponse): JSX.Element {
+  const modelUrl: string = "https://raw.githubusercontent.com/kiegroup/kogito-tooling/master/packages/online-editor/static/samples/sample.dmn#/editor/dmn";
+  const editorUrl = `https://kiegroup.github.io/kogito-online/?file=${modelUrl}`;
   const kogitoIframe = () => {
-    return { __html: `<iframe src=${editorUrl} data-key="${executionId}"></iframe>` };
+    return { __html: `<iframe src=${editorUrl}"></iframe>` };
   };
   return <div className="model-diagram__iframe" dangerouslySetInnerHTML={kogitoIframe()} />;
 }
 
-function makePMMLEditor(xml: string): JSX.Element {
-  return <LinearRegressionViewer xml={xml} />;
+function makePMMLEditor(model: IExecutionModelResponse): JSX.Element {
+  return <LinearRegressionViewer xml={model.model} />;
 }
 
 const DEFAULT: JSX.Element = makeUnknownModel();
 
 const ModelDiagram = (props: Props) => {
 
-  const { executionId = undefined, modelType = undefined, xml = undefined } = props;
+  const { model } = props;
+  const type: string = model.type;
 
-  switch (modelType) {
-    case "DMN":
-      if (executionId !== undefined) {
-        return makeDMNEditor(executionId as string);
-      }
-      break;
-    case "PMML":
-      if (xml !== undefined) {
-        return makePMMLEditor(xml as string);
-      }
-      break;
+  switch (type) {
+    case DMN1_2:
+      return makeDMNEditor(model);
+    case PMML4_4:
+      return makePMMLEditor(model);
   }
 
   return DEFAULT;

--- a/front-end-poc/src/ModelLookup/ModelDiagram.tsx
+++ b/front-end-poc/src/ModelLookup/ModelDiagram.tsx
@@ -5,6 +5,11 @@ import { LinearRegressionViewer } from "./pmml/LinearRegressionViewer";
 const DMN1_2: string = "http://www.omg.org/spec/DMN/20151101/dmn.xsd";
 const PMML4_4: string = "http://www.dmg.org/PMML-4_4";
 
+const model1Url: string = "https://gist.githubusercontent.com/r00ta/c5077ac1f12746e356e1d4f03620ee05/raw/a3d2a865398547a18010e78dd4c1b0d76cc85d99/myMortgage.dmn";
+const defaultModelUrl: string = "https://raw.githubusercontent.com/kiegroup/kogito-tooling/master/packages/online-editor/static/samples/sample.dmn";
+
+let models: Map<string, string> = new Map([["myMortgage", model1Url]]);
+
 interface Props {
   model: IExecutionModelResponse;
 }
@@ -14,8 +19,8 @@ function makeUnknownModel(): JSX.Element {
 }
 
 function makeDMNEditor(model: IExecutionModelResponse): JSX.Element {
-  const modelUrl: string = "https://raw.githubusercontent.com/kiegroup/kogito-tooling/master/packages/online-editor/static/samples/sample.dmn#/editor/dmn";
-  const editorUrl = `https://kiegroup.github.io/kogito-online/?file=${modelUrl}`;
+  const modelUrl: string = models.get(model.name) ?? defaultModelUrl;
+  const editorUrl = `https://kiegroup.github.io/kogito-online/?file=${modelUrl}#/editor/dmn`;
   const kogitoIframe = () => {
     return { __html: `<iframe src=${editorUrl}"></iframe>` };
   };

--- a/front-end-poc/src/ModelLookup/ModelLookup.tsx
+++ b/front-end-poc/src/ModelLookup/ModelLookup.tsx
@@ -1,11 +1,10 @@
 import { Divider, PageSection, PageSectionVariants, Spinner } from "@patternfly/react-core";
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useParams } from "react-router-dom";
-import { IExecutionRouteParams } from "../Audit/types";
+import { IExecutionModelResponse, IExecutionRouteParams } from "../Audit/types";
 import { getModelDetail } from "../Shared/api/audit.api";
 import ModelDiagram from "./ModelDiagram";
 import "./ModelLookup.scss";
-
 
 const ModelLookup = () => {
     const { executionId } = useParams<IExecutionRouteParams>();
@@ -16,10 +15,8 @@ const ModelLookup = () => {
         getModelDetail(executionId)
             .then(response => {
                 if (didMount) {
-                    const modelType: string = response.data[0].modelType;
-                    const xml: string = response.data[0].xml;
-
-                    setViewer(<ModelDiagram executionId={executionId} modelType={modelType} xml={xml} />);
+                    const model: IExecutionModelResponse = response.data[0] as IExecutionModelResponse;
+                    setViewer(<ModelDiagram model={model} />);
                 }
             })
             .catch(() => { });

--- a/front-end-poc/src/Shared/api/audit.api.ts
+++ b/front-end-poc/src/Shared/api/audit.api.ts
@@ -4,7 +4,6 @@ import { AxiosRequestConfig } from "axios";
 const EXECUTIONS_PATH = "/executions";
 const DECISIONS_PATH = EXECUTIONS_PATH + "/decisions";
 const PROCESS_PATH = EXECUTIONS_PATH + "/processes";
-const MODELS_PATH = "/models";
 
 export type ExecutionType = 'decision' | 'process';
 
@@ -70,16 +69,16 @@ const getDecisionFeatureScores = (executionId: string) => {
 }
 
 const getDecisionOutcomeDetail = (executionId: string, outcomeId: string) => {
-    const getDecisionOutcomeDetailConfig : AxiosRequestConfig = {
+    const getDecisionOutcomeDetailConfig: AxiosRequestConfig = {
         url: `${DECISIONS_PATH}/${executionId}/outcomes/${outcomeId}`,
         method: 'get'
     }
     return httpClient(getDecisionOutcomeDetailConfig);
 }
 
-const getModelDetail = (id: string) => {
+const getModelDetail = (executionId: string) => {
     const getModelDetailConfig: AxiosRequestConfig = {
-        url: `${MODELS_PATH}/${id}`,
+        url: `${DECISIONS_PATH}/${executionId}/model`,
         method: 'get'
     }
     return httpClient(getModelDetailConfig);


### PR DESCRIPTION
Cherry-pick of https://github.com/kiegroup/trusty-ai-sandbox/pull/48 for `FAI-133-demo`

It also includes a change to use the model(names) provided by @r00ta to date.

@r00ta Please be sure to send me any others (fraud?) atm I only have `myMortgage`.