### PR TITLE
FAI-241: Model definition endpoint - UI changes

### DIFF
--- a/front-end-poc/README.md
+++ b/front-end-poc/README.md
@@ -10,14 +10,6 @@ To install dependencies you need to have yarn installed globally and run in the 
 yarn install
 ```
 
-### Install GWT editors
-
-To install the GWT editors to view DMN models you need to run the following in the terminal before running the project:
-
-```
-yarn run prepare
-```
-
 ### Run the project
 
 Compile and run the project in development mode with:

--- a/front-end-poc/README.md
+++ b/front-end-poc/README.md
@@ -5,38 +5,48 @@ This project is a PoC for the Audit section of a XAI service
 ### Install dependencies
 
 To install dependencies you need to have yarn installed globally and run in the terminal:
+
 ```
 yarn install
 ```
+
+### Install GWT editors
+
+To install the GWT editors to view DMN models you need to run the following in the terminal before running the project:
+
+```
+yarn run prepare
+```
+
 ### Run the project
 
 Compile and run the project in development mode with:
+
 ```
 yarn run start
 ```
 
 Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
 
-The page will reload if you make edits.<br />
-You will also see any lint errors in the console.
+The page will reload if you make edits.<br /> You will also see any lint errors in the console.
 
 The project connects to APIs at `localhost:1336`. While the APIs are still not ready, you can run the following command in a different terminal tab to run a mocked api server:
+
 ```
 yarn run mock-api
 ```
 
 ### Build the project
+
 ```
 yarn run build
 ```
-Builds the app for production to the `build` folder.<br />
-It correctly bundles React in production mode and optimizes the build for the best performance.
 
-The build is minified and the filenames include the hashes.<br />
-Your app is ready to be deployed!
+Builds the app for production to the `build` folder.<br /> It correctly bundles React in production mode and optimizes the build for the best performance.
+
+The build is minified and the filenames include the hashes.<br /> Your app is ready to be deployed!
 
 See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
-
 
 ### Notes
 

--- a/front-end-poc/api-mock/routes.json
+++ b/front-end-poc/api-mock/routes.json
@@ -1,8 +1,8 @@
 {
+  "/executions/:executionId/model": "/models/:executionId",
   "/executions/:executionType/:executionId": "/decisions/:executionId",
   "/executions/:executionType/:executionId/structuredInputs": "/inputs?executionId=:executionId",
   "/executions/:executionType/:executionId/outcomes": "/outcomes?header.executionId=:executionId&singular=1",
   "/executions/:executionType/:executionId/outcomes/:outcomeId": "/outcomeDetail?outcomeId=:outcomeId&singular=1",
-  "/executions/:executionType/:executionId/featureImportance": "/featureImportance?executionId=:executionId",
-  "/executions/:executionType/:executionId/model": "/models/:executionId"
+  "/executions/:executionType/:executionId/featureImportance": "/featureImportance?executionId=:executionId"
 }

--- a/front-end-poc/src/ModelLookup/ModelDiagram.tsx
+++ b/front-end-poc/src/ModelLookup/ModelDiagram.tsx
@@ -31,6 +31,7 @@ function makeDMNEditor(model: IExecutionModelResponse,
       file={file}
       router={router}
       channelType={ChannelType.EMBEDDED}
+      envelopeUri={process.env.PUBLIC_URL + '/envelope/envelope.html'}
     />);
 }
 

--- a/front-end-poc/src/Shared/api/audit.api.ts
+++ b/front-end-poc/src/Shared/api/audit.api.ts
@@ -78,7 +78,7 @@ const getDecisionOutcomeDetail = (executionId: string, outcomeId: string) => {
 
 const getModelDetail = (executionId: string) => {
   const getModelDetailConfig: AxiosRequestConfig = {
-    url: `${DECISIONS_PATH}/${executionId}/model`,
+    url: `${EXECUTIONS_PATH}/${executionId}/model`,
     method: "get",
   };
   return httpClient(getModelDetailConfig);


### PR DESCRIPTION
See https://issues.redhat.com/browse/FAI-241

This also relates to changes made [here](https://github.com/kiegroup/kogito-apps/pull/370) exposing the Model REST endpoint as `executions/{executionId}/model`

@kelvah This no doubt impacts https://github.com/kiegroup/kogito-apps/pull/330/. 

I can submit a new PR for `kogito-apps` once your PR is merged.