### PR TITLE
[FAI-286] Implement feature distance scaling

### DIFF
--- a/explainability/core/counterfactuals/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualConfigurationFactory.java
+++ b/explainability/core/counterfactuals/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualConfigurationFactory.java
@@ -17,8 +17,20 @@ import java.util.List;
 
 public class CounterfactualConfigurationFactory {
 
+    private static final long DEFAULT_TIME_LIMIT = 30;
+    private static final int DEFAULT_TABU_SIZE = 70;
+    private static final int DEFAULT_ACCEPTED_COUNT = 5000;
+
+
     private CounterfactualConfigurationFactory() {
 
+    }
+
+    public static SolverConfig createDefaultSolverConfig() {
+        return CounterfactualConfigurationFactory
+                .createSolverConfig(DEFAULT_TIME_LIMIT,
+                        DEFAULT_TABU_SIZE,
+                        DEFAULT_ACCEPTED_COUNT);
     }
 
     public static SolverConfig createSolverConfig(Long timeLimit, int tabuSize, int acceptedCount) {

--- a/explainability/core/counterfactuals/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualExplainer.java
+++ b/explainability/core/counterfactuals/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualExplainer.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -41,9 +42,6 @@ import java.util.concurrent.ForkJoinPool;
  */
 public class CounterfactualExplainer implements LocalExplainer<List<CounterfactualEntity>> {
 
-    private static final long DEFAULT_TIME_LIMIT = 30;
-    private static final int DEFAULT_TABU_SIZE = 70;
-    private static final int DEFAULT_ACCEPTED_COUNT = 5000;
     private static final Logger logger =
             LoggerFactory.getLogger(CounterfactualExplainer.class);
     private final List<Output> goal;
@@ -51,24 +49,7 @@ public class CounterfactualExplainer implements LocalExplainer<List<Counterfactu
     private final List<Boolean> constraints;
     private final SolverConfig solverConfig;
     private final Executor executor;
-    private DataDistribution dataDistribution = null;
-
-
-    /**
-     * Create a new {@link CounterfactualExplainer} using OptaPlanner as the underlying engine.
-     *
-     * @param dataDomain   A {@link DataDomain} which specifies the search space domain
-     * @param contraints   A list specifying by index which features are constrained
-     * @param goal         A collection of {@link Output} representing the desired outcome
-     * @param solverConfig An OptaPlanner {@link SolverConfig} configuration
-     */
-    public CounterfactualExplainer(DataDomain dataDomain, List<Boolean> contraints, List<Output> goal, SolverConfig solverConfig, Executor executor) {
-        this.constraints = contraints;
-        this.goal = goal;
-        this.dataDomain = dataDomain;
-        this.solverConfig = solverConfig;
-        this.executor = executor;
-    }
+    private final DataDistribution dataDistribution;
 
     /**
      * Create a new {@link CounterfactualExplainer} using OptaPlanner as the underlying engine.
@@ -79,65 +60,22 @@ public class CounterfactualExplainer implements LocalExplainer<List<Counterfactu
      * @param goal             A collection of {@link Output} representing the desired outcome
      * @param solverConfig     An OptaPlanner {@link SolverConfig} configuration
      */
-    public CounterfactualExplainer(DataDistribution dataDistribution, DataDomain dataDomain, List<Boolean> contraints, List<Output> goal, SolverConfig solverConfig, Executor executor) {
+    public CounterfactualExplainer(DataDistribution dataDistribution,
+                                   DataDomain dataDomain,
+                                   List<Boolean> contraints,
+                                   List<Output> goal,
+                                   SolverConfig solverConfig,
+                                   Executor executor) {
+        this.dataDistribution = dataDistribution;
+        this.dataDomain = dataDomain;
         this.constraints = contraints;
         this.goal = goal;
-        this.dataDomain = dataDomain;
         this.solverConfig = solverConfig;
         this.executor = executor;
-        this.dataDistribution = dataDistribution;
     }
 
-    public CounterfactualExplainer(DataDomain dataDomain, List<Boolean> constraints, List<Output> goal) {
-        this(dataDomain,
-                constraints,
-                goal,
-                CounterfactualConfigurationFactory.createSolverConfig(
-                        DEFAULT_TIME_LIMIT,
-                        DEFAULT_TABU_SIZE,
-                        DEFAULT_ACCEPTED_COUNT),
-                ForkJoinPool.commonPool()
-        );
-    }
-
-    public CounterfactualExplainer(DataDistribution dataDistribution, DataDomain dataDomain, List<Boolean> constraints, List<Output> goal) {
-        this(dataDistribution,
-                dataDomain,
-                constraints,
-                goal,
-                CounterfactualConfigurationFactory.createSolverConfig(
-                        DEFAULT_TIME_LIMIT,
-                        DEFAULT_TABU_SIZE,
-                        DEFAULT_ACCEPTED_COUNT),
-                ForkJoinPool.commonPool()
-        );
-    }
-
-    /**
-     * Create a new {@link CounterfactualExplainer} using OptaPlanner as the underlying engine.
-     *
-     * @param dataDomain    A {@link DataDomain} which specifies the search space domain
-     * @param contraints    A list specifying by index which features are constrained
-     * @param goal          A collection of {@link Output} representing the desired outcome
-     * @param timeLimit     Computational time spent limit in seconds
-     * @param tabuSize      Tabu search limit
-     * @param acceptedCount How many accepted moves should be evaluated during each step
-     * @see "Glover, Fred. "Tabu search—part I." ORSA Journal on computing 1, no. 3 (1989): 190-206"
-     */
-    public CounterfactualExplainer(DataDomain dataDomain, List<Boolean> contraints, List<Output> goal, Long timeLimit, int tabuSize, int acceptedCount, Executor executor) {
-        this(dataDomain, contraints, goal, CounterfactualConfigurationFactory.createSolverConfig(timeLimit, tabuSize, acceptedCount), executor);
-    }
-
-    public CounterfactualExplainer(DataDistribution dataDistribution, DataDomain dataDomain, List<Boolean> contraints, List<Output> goal, Long timeLimit, int tabuSize, int acceptedCount, Executor executor) {
-        this(dataDistribution, dataDomain, contraints, goal, CounterfactualConfigurationFactory.createSolverConfig(timeLimit, tabuSize, acceptedCount), executor);
-    }
-
-    public CounterfactualExplainer(DataDistribution dataDistribution, DataDomain dataDomain, List<Boolean> contraints, List<Output> goal, Long timeLimit, int tabuSize, int acceptedCount) {
-        this(dataDistribution, dataDomain, contraints, goal, CounterfactualConfigurationFactory.createSolverConfig(timeLimit, tabuSize, acceptedCount), ForkJoinPool.commonPool());
-    }
-
-    public CounterfactualExplainer(DataDomain dataDomain, List<Boolean> contraints, List<Output> goal, Long timeLimit, int tabuSize, int acceptedCount) {
-        this(dataDomain, contraints, goal, CounterfactualConfigurationFactory.createSolverConfig(timeLimit, tabuSize, acceptedCount), ForkJoinPool.commonPool());
+    public static Builder builder(List<Output> goal, List<Boolean> constraints, DataDomain dataDomain) {
+        return new Builder(goal, constraints, dataDomain);
     }
 
     private Executor getExecutor() {
@@ -148,15 +86,18 @@ public class CounterfactualExplainer implements LocalExplainer<List<Counterfactu
         final List<CounterfactualEntity> entities = new ArrayList<>();
 
         for (int i = 0; i < predictionInput.getFeatures().size(); i++) {
+
             final Feature feature = predictionInput.getFeatures().get(i);
             final Boolean isConstrained = constraints.get(i);
             final FeatureDomain featureDomain = dataDomain.getFeatureDomains().get(i);
-            FeatureDistribution featureDistribution = null;
             // If a data distribution was specified, use it to instantiate the counterfactual entity
-            if (dataDistribution != null) {
-                featureDistribution = dataDistribution.getFeatureDistributions().get(i);
-            }
-            final CounterfactualEntity counterfactualEntity = CounterfactualEntityFactory.from(feature, isConstrained, featureDomain, featureDistribution);
+            final int featureIndex = i;
+            final FeatureDistribution featureDistribution = Optional
+                    .ofNullable(dataDistribution)
+                    .map(dd -> dd.getFeatureDistributions().get(featureIndex))
+                    .orElse(null);
+            final CounterfactualEntity counterfactualEntity = CounterfactualEntityFactory
+                    .from(feature, isConstrained, featureDomain, featureDistribution);
             entities.add(counterfactualEntity);
         }
         return entities;
@@ -188,5 +129,50 @@ public class CounterfactualExplainer implements LocalExplainer<List<Counterfactu
                 solverManager.close();
             }
         }, this.executor);
+    }
+
+    public static class Builder {
+
+
+        private DataDistribution dataDistribution = null;
+        private final DataDomain dataDomain;
+        private final List<Boolean> constraints;
+        private final List<Output> goal;
+        private Executor executor = ForkJoinPool.commonPool();
+        private SolverConfig solverConfig = null;
+
+        private Builder(List<Output> goal, List<Boolean> constraints, DataDomain dataDomain) {
+            this.goal = goal;
+            this.constraints = constraints;
+            this.dataDomain = dataDomain;
+        }
+
+        public Builder withDataDistribution(DataDistribution dataDistribution) {
+            this.dataDistribution = dataDistribution;
+            return this;
+        }
+
+        public Builder withExecutor(Executor executor) {
+            this.executor = executor;
+            return this;
+        }
+
+        public Builder withSolverConfig(SolverConfig solverConfig) {
+            this.solverConfig = solverConfig;
+            return this;
+        }
+
+        public CounterfactualExplainer build() {
+            // Create a default solver configuration if none provided
+            if (this.solverConfig == null) {
+                this.solverConfig = CounterfactualConfigurationFactory.createDefaultSolverConfig();
+            }
+            return new CounterfactualExplainer(dataDistribution,
+                    dataDomain,
+                    constraints,
+                    goal,
+                    solverConfig,
+                    executor);
+        }
     }
 }

--- a/explainability/core/counterfactuals/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualExplainer.java
+++ b/explainability/core/counterfactuals/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualExplainer.java
@@ -61,7 +61,7 @@ public class CounterfactualExplainer implements LocalExplainer<List<Counterfactu
      * @param goal             A collection of {@link Output} representing the desired outcome
      * @param solverConfig     An OptaPlanner {@link SolverConfig} configuration
      */
-    public CounterfactualExplainer(DataDistribution dataDistribution,
+    protected CounterfactualExplainer(DataDistribution dataDistribution,
                                    DataDomain dataDomain,
                                    List<Boolean> contraints,
                                    List<Output> goal,
@@ -126,7 +126,7 @@ public class CounterfactualExplainer implements LocalExplainer<List<Counterfactu
         }, this.executor);
     }
 
-    protected static class Builder {
+    public static class Builder {
 
 
         private final DataDomain dataDomain;

--- a/explainability/core/counterfactuals/src/main/java/org/kie/kogito/explainability/local/counterfactual/entities/CounterfactualEntityFactory.java
+++ b/explainability/core/counterfactuals/src/main/java/org/kie/kogito/explainability/local/counterfactual/entities/CounterfactualEntityFactory.java
@@ -16,6 +16,7 @@
 package org.kie.kogito.explainability.local.counterfactual.entities;
 
 import org.kie.kogito.explainability.model.Feature;
+import org.kie.kogito.explainability.model.FeatureDistribution;
 import org.kie.kogito.explainability.model.FeatureDomain;
 import org.kie.kogito.explainability.model.Type;
 
@@ -26,13 +27,17 @@ public class CounterfactualEntityFactory {
     }
 
     public static CounterfactualEntity from(Feature feature, Boolean isConstrained, FeatureDomain featureDomain) {
+        return CounterfactualEntityFactory.from(feature, isConstrained, featureDomain, null);
+    }
+
+    public static CounterfactualEntity from(Feature feature, Boolean isConstrained, FeatureDomain featureDomain, FeatureDistribution featureDistribution) {
 
         CounterfactualEntity entity = null;
         if (feature.getType() == Type.NUMBER) {
             if (feature.getValue().getUnderlyingObject() instanceof Double) {
-                entity = DoubleEntity.from(feature, featureDomain.getStart(), featureDomain.getEnd(), isConstrained);
+                entity = DoubleEntity.from(feature, featureDomain.getStart(), featureDomain.getEnd(), featureDistribution, isConstrained);
             } else if (feature.getValue().getUnderlyingObject() instanceof Integer) {
-                entity = IntegerEntity.from(feature, featureDomain.getStart().intValue(), featureDomain.getEnd().intValue(), isConstrained);
+                entity = IntegerEntity.from(feature, featureDomain.getStart().intValue(), featureDomain.getEnd().intValue(), featureDistribution, isConstrained);
             }
         } else if (feature.getType() == Type.BOOLEAN) {
             entity = BooleanEntity.from(feature, isConstrained);
@@ -43,6 +48,7 @@ public class CounterfactualEntityFactory {
         }
         return entity;
     }
+
 
 }
 

--- a/explainability/core/counterfactuals/src/test/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualExplainerTest.java
+++ b/explainability/core/counterfactuals/src/test/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualExplainerTest.java
@@ -20,6 +20,7 @@ import org.kie.kogito.explainability.Config;
 import org.kie.kogito.explainability.TestUtils;
 import org.kie.kogito.explainability.local.counterfactual.entities.CounterfactualEntity;
 import org.kie.kogito.explainability.model.*;
+import org.optaplanner.core.config.solver.SolverConfig;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -55,7 +56,13 @@ class CounterfactualExplainerTest {
                 constraints.add(false);
             }
             final DataDomain dataDomain = new DataDomain(featureBoundaries);
-            CounterfactualExplainer counterfactualExplainer = new CounterfactualExplainer(dataDomain, constraints, goal, 1L, 70, 5000);
+            final SolverConfig solverConfig = CounterfactualConfigurationFactory
+                    .createSolverConfig(1L, 70, 5000);
+            final CounterfactualExplainer counterfactualExplainer =
+                    CounterfactualExplainer
+                            .builder(goal, constraints, dataDomain)
+                            .withSolverConfig(solverConfig)
+                            .build();
 
             PredictionInput input = new PredictionInput(features);
             PredictionProvider model = TestUtils.getSumSkipModel(0);
@@ -97,7 +104,14 @@ class CounterfactualExplainerTest {
             featureBoundaries.add(FeatureDomain.numerical(0.0, 1000.0));
 
             final DataDomain dataDomain = new DataDomain(featureBoundaries);
-            CounterfactualExplainer counterfactualExplainer = new CounterfactualExplainer(dataDomain, constraints, goal, 5L, 70, 5000);
+
+            final SolverConfig solverConfig = CounterfactualConfigurationFactory
+                    .createSolverConfig(1L, 70, 5000);
+            final CounterfactualExplainer counterfactualExplainer =
+                    CounterfactualExplainer
+                            .builder(goal, constraints, dataDomain)
+                            .withSolverConfig(solverConfig)
+                            .build();
 
             final double center = 500.0;
             final double epsilon = 10.0;
@@ -148,7 +162,14 @@ class CounterfactualExplainerTest {
             constraints.set(0, true);
             constraints.set(3, true);
             final DataDomain dataDomain = new DataDomain(featureBoundaries);
-            CounterfactualExplainer counterfactualExplainer = new CounterfactualExplainer(dataDomain, constraints, goal, 5L, 70, 5000);
+
+            final SolverConfig solverConfig = CounterfactualConfigurationFactory
+                    .createSolverConfig(5L, 70, 5000);
+            final CounterfactualExplainer counterfactualExplainer =
+                    CounterfactualExplainer
+                            .builder(goal, constraints, dataDomain)
+                            .withSolverConfig(solverConfig)
+                            .build();
 
             final double center = 500.0;
             final double epsilon = 10.0;
@@ -207,7 +228,14 @@ class CounterfactualExplainerTest {
             constraints.set(0, true);
             constraints.set(3, true);
             final DataDomain dataDomain = new DataDomain(featureBoundaries);
-            CounterfactualExplainer counterfactualExplainer = new CounterfactualExplainer(dataDistribution, dataDomain, constraints, goal, 5L, 70, 5000);
+            final SolverConfig solverConfig = CounterfactualConfigurationFactory
+                    .createSolverConfig(5L, 70, 5000);
+            final CounterfactualExplainer counterfactualExplainer =
+                    CounterfactualExplainer
+                            .builder(goal, constraints, dataDomain)
+                            .withDataDistribution(dataDistribution)
+                            .withSolverConfig(solverConfig)
+                            .build();
 
             final double center = 500.0;
             final double epsilon = 10.0;
@@ -254,7 +282,14 @@ class CounterfactualExplainerTest {
             // add a constraint
             constraints.set(2, true);
             final DataDomain dataDomain = new DataDomain(featureBoundaries);
-            CounterfactualExplainer counterfactualExplainer = new CounterfactualExplainer(dataDomain, constraints, goal, 5L, 70, 5000);
+
+            final SolverConfig solverConfig = CounterfactualConfigurationFactory
+                    .createSolverConfig(5L, 70, 5000);
+            final CounterfactualExplainer counterfactualExplainer =
+                    CounterfactualExplainer
+                            .builder(goal, constraints, dataDomain)
+                            .withSolverConfig(solverConfig)
+                            .build();
 
             final double center = 500.0;
             final double epsilon = 10.0;
@@ -299,7 +334,14 @@ class CounterfactualExplainerTest {
             featureBoundaries.add(FeatureDomain.categorical("+", "-", "/", "*"));
             constraints.add(false);
             final DataDomain dataDomain = new DataDomain(featureBoundaries);
-            CounterfactualExplainer counterfactualExplainer = new CounterfactualExplainer(dataDomain, constraints, goal, 5L, 70, 5000);
+
+            final SolverConfig solverConfig = CounterfactualConfigurationFactory
+                    .createSolverConfig(5L, 70, 5000);
+            final CounterfactualExplainer counterfactualExplainer =
+                    CounterfactualExplainer
+                            .builder(goal, constraints, dataDomain)
+                            .withSolverConfig(solverConfig)
+                            .build();
 
             PredictionInput input = new PredictionInput(features);
             PredictionProvider model = TestUtils.getSymbolicArithmeticModel();

--- a/explainability/core/counterfactuals/src/test/java/org/kie/kogito/explainability/local/counterfactual/entities/DoubleEntityTest.java
+++ b/explainability/core/counterfactuals/src/test/java/org/kie/kogito/explainability/local/counterfactual/entities/DoubleEntityTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.explainability.local.counterfactual.entities;
+
+import org.junit.jupiter.api.Test;
+import org.kie.kogito.explainability.model.Feature;
+import org.kie.kogito.explainability.model.FeatureDistribution;
+import org.kie.kogito.explainability.model.FeatureDomain;
+import org.kie.kogito.explainability.model.FeatureFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DoubleEntityTest {
+
+
+    @Test
+    void distanceUnscaled() {
+        final Feature doubleFeature = FeatureFactory.newNumericalFeature("feature-double", 20.0);
+        final FeatureDomain featureDomain = FeatureDomain.numerical(0.0, 40.0);
+        DoubleEntity entity = (DoubleEntity) CounterfactualEntityFactory.from(doubleFeature, false, featureDomain);
+        entity.proposedValue = 30.0;
+        assertEquals(10.0, entity.distance());
+    }
+
+    @Test
+    void distanceScaled() {
+        final Feature doubleFeature = FeatureFactory.newNumericalFeature("feature-double", 20.0);
+        final FeatureDomain featureDomain = FeatureDomain.numerical(0.0, 40.0);
+        final FeatureDistribution featureDistribution = new FeatureDistribution(0.0, 40.0, 25.0, 2.0);
+        DoubleEntity entity = (DoubleEntity) CounterfactualEntityFactory.from(doubleFeature, false, featureDomain, featureDistribution);
+        entity.proposedValue = 30.0;
+        assertEquals(2.5, entity.distance());
+    }
+
+}

--- a/explainability/core/counterfactuals/src/test/java/org/kie/kogito/explainability/local/counterfactual/entities/IntegerEntityTest.java
+++ b/explainability/core/counterfactuals/src/test/java/org/kie/kogito/explainability/local/counterfactual/entities/IntegerEntityTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.explainability.local.counterfactual.entities;
+
+import org.junit.jupiter.api.Test;
+import org.kie.kogito.explainability.model.Feature;
+import org.kie.kogito.explainability.model.FeatureDistribution;
+import org.kie.kogito.explainability.model.FeatureDomain;
+import org.kie.kogito.explainability.model.FeatureFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class IntegerEntityTest {
+
+
+    @Test
+    void distanceUnscaled() {
+        final Feature integerFeature = FeatureFactory.newNumericalFeature("feature-integer", 20);
+        final FeatureDomain featureDomain = FeatureDomain.numerical(0, 100);
+        IntegerEntity entity = (IntegerEntity) CounterfactualEntityFactory.from(integerFeature, false, featureDomain);
+        entity.proposedValue = 40;
+        assertEquals(20.0, entity.distance());
+    }
+
+    @Test
+    void distanceScaled() {
+        final Feature integerFeature = FeatureFactory.newNumericalFeature("feature-integer", 20);
+        final FeatureDomain featureDomain = FeatureDomain.numerical(0, 100);
+        final FeatureDistribution featureDistribution = new FeatureDistribution(0.0, 40.0, 25.0, 4.0);
+        IntegerEntity entity = (IntegerEntity) CounterfactualEntityFactory.from(integerFeature, false, featureDomain, featureDistribution);
+        entity.proposedValue = 40;
+        assertEquals(1.25, entity.distance());
+
+    }
+
+}


### PR DESCRIPTION
This PR implements feature distance scaling for counterfactual search when that information is available (specified using `DataDistribution`).
If the feature distribution information is not available, the counterfactual search behaves as previously (using unscaled distances).