### PR TITLE
[FAI-298] Allow counterfactual search fixed step termination

### DIFF
--- a/explainability/core/counterfactuals/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualConfigurationFactory.java
+++ b/explainability/core/counterfactuals/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualConfigurationFactory.java
@@ -21,46 +21,74 @@ public class CounterfactualConfigurationFactory {
     private static final int DEFAULT_TABU_SIZE = 70;
     private static final int DEFAULT_ACCEPTED_COUNT = 5000;
 
-
     private CounterfactualConfigurationFactory() {
 
     }
 
-    public static SolverConfig createDefaultSolverConfig() {
-        return CounterfactualConfigurationFactory
-                .createSolverConfig(DEFAULT_TIME_LIMIT,
-                        DEFAULT_TABU_SIZE,
-                        DEFAULT_ACCEPTED_COUNT);
+    public static CounterfactualConfigurationFactory.Builder builder() {
+        return new Builder();
     }
 
-    public static SolverConfig createSolverConfig(Long timeLimit, int tabuSize, int acceptedCount) {
-        SolverConfig solverConfig = new SolverConfig();
+    public static class Builder {
 
-        solverConfig.withEntityClasses(IntegerEntity.class, DoubleEntity.class, BooleanEntity.class, CategoricalEntity.class);
-        solverConfig.setSolutionClass(CounterfactualSolution.class);
+        private TerminationConfig terminationConfig = null;
+        private int tabuSize = DEFAULT_TABU_SIZE;
+        private int acceptedCount = DEFAULT_ACCEPTED_COUNT;
 
-        ScoreDirectorFactoryConfig scoreDirectorFactoryConfig = new ScoreDirectorFactoryConfig();
-        scoreDirectorFactoryConfig.setEasyScoreCalculatorClass(CounterFactualScoreCalculator.class);
-        solverConfig.setScoreDirectorFactoryConfig(scoreDirectorFactoryConfig);
+        private Builder() {
 
-        TerminationConfig terminationConfig = new TerminationConfig();
-        terminationConfig.setSecondsSpentLimit(timeLimit);
-        solverConfig.setTerminationConfig(terminationConfig);
+        }
 
-        LocalSearchAcceptorConfig acceptorConfig = new LocalSearchAcceptorConfig();
-        acceptorConfig.setEntityTabuSize(tabuSize);
+        public SolverConfig build() {
+            // create a default termination config if none supplied
+            if (terminationConfig == null) {
+                terminationConfig = new TerminationConfig();
+                terminationConfig.setSecondsSpentLimit(DEFAULT_TIME_LIMIT);
+            }
 
-        LocalSearchForagerConfig localSearchForagerConfig = new LocalSearchForagerConfig();
-        localSearchForagerConfig.setAcceptedCountLimit(acceptedCount);
+            SolverConfig solverConfig = new SolverConfig();
 
-        LocalSearchPhaseConfig localSearchPhaseConfig = new LocalSearchPhaseConfig();
-        localSearchPhaseConfig.setAcceptorConfig(acceptorConfig);
-        localSearchPhaseConfig.setForagerConfig(localSearchForagerConfig);
+            solverConfig.withEntityClasses(IntegerEntity.class, DoubleEntity.class, BooleanEntity.class, CategoricalEntity.class);
+            solverConfig.setSolutionClass(CounterfactualSolution.class);
 
-        List<PhaseConfig> phaseConfigs = new ArrayList<>();
-        phaseConfigs.add(localSearchPhaseConfig);
+            ScoreDirectorFactoryConfig scoreDirectorFactoryConfig = new ScoreDirectorFactoryConfig();
+            scoreDirectorFactoryConfig.setEasyScoreCalculatorClass(CounterFactualScoreCalculator.class);
+            solverConfig.setScoreDirectorFactoryConfig(scoreDirectorFactoryConfig);
 
-        solverConfig.setPhaseConfigList(phaseConfigs);
-        return solverConfig;
+            solverConfig.setTerminationConfig(terminationConfig);
+
+            LocalSearchAcceptorConfig acceptorConfig = new LocalSearchAcceptorConfig();
+            acceptorConfig.setEntityTabuSize(tabuSize);
+
+            LocalSearchForagerConfig localSearchForagerConfig = new LocalSearchForagerConfig();
+            localSearchForagerConfig.setAcceptedCountLimit(acceptedCount);
+
+            LocalSearchPhaseConfig localSearchPhaseConfig = new LocalSearchPhaseConfig();
+            localSearchPhaseConfig.setAcceptorConfig(acceptorConfig);
+            localSearchPhaseConfig.setForagerConfig(localSearchForagerConfig);
+
+            List<PhaseConfig> phaseConfigs = new ArrayList<>();
+            phaseConfigs.add(localSearchPhaseConfig);
+
+            solverConfig.setPhaseConfigList(phaseConfigs);
+            return solverConfig;
+        }
+
+        public Builder withTabuSize(int size) {
+            this.tabuSize = size;
+            return this;
+        }
+
+        public Builder withAcceptedCount(int count) {
+            this.acceptedCount = count;
+            return this;
+        }
+
+        public Builder withTerminationConfig(TerminationConfig terminationConfig) {
+            this.terminationConfig = terminationConfig;
+            return this;
+        }
+
     }
+
 }

--- a/explainability/core/counterfactuals/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualConfigurationFactory.java
+++ b/explainability/core/counterfactuals/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualConfigurationFactory.java
@@ -89,6 +89,14 @@ public class CounterfactualConfigurationFactory {
             return this;
         }
 
+        public Builder withScoreCalculationCountLimit(long scoreCalculationCountLimit) {
+            if (this.terminationConfig == null) {
+                this.terminationConfig = new TerminationConfig();
+            }
+            this.terminationConfig.setScoreCalculationCountLimit(scoreCalculationCountLimit);
+            return this;
+        }
+
     }
 
 }

--- a/explainability/core/counterfactuals/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualExplainer.java
+++ b/explainability/core/counterfactuals/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualExplainer.java
@@ -160,7 +160,7 @@ public class CounterfactualExplainer implements LocalExplainer<List<Counterfactu
         public CounterfactualExplainer build() {
             // Create a default solver configuration if none provided
             if (this.solverConfig == null) {
-                this.solverConfig = CounterfactualConfigurationFactory.createDefaultSolverConfig();
+                this.solverConfig = CounterfactualConfigurationFactory.builder().build();
             }
             return new CounterfactualExplainer(dataDistribution,
                     dataDomain,

--- a/explainability/core/counterfactuals/src/test/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualExplainerTest.java
+++ b/explainability/core/counterfactuals/src/test/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualExplainerTest.java
@@ -59,11 +59,9 @@ class CounterfactualExplainerTest {
                 constraints.add(false);
             }
             final DataDomain dataDomain = new DataDomain(featureBoundaries);
-            TerminationConfig stepTerminationConfig = new TerminationConfig();
             // for the purpose of this test, only a few steps are necessary
-            stepTerminationConfig.setScoreCalculationCountLimit(10L);
             final SolverConfig solverConfig = CounterfactualConfigurationFactory
-                    .builder().withTerminationConfig(stepTerminationConfig).build();
+                    .builder().withScoreCalculationCountLimit(10L).build();
             final CounterfactualExplainer counterfactualExplainer =
                     CounterfactualExplainer
                             .builder(goal, constraints, dataDomain)
@@ -111,10 +109,9 @@ class CounterfactualExplainerTest {
 
             final DataDomain dataDomain = new DataDomain(featureBoundaries);
 
-            TerminationConfig stepTerminationConfig = new TerminationConfig();
-            stepTerminationConfig.setScoreCalculationCountLimit(steps);
+
             final SolverConfig solverConfig = CounterfactualConfigurationFactory
-                    .builder().withTerminationConfig(stepTerminationConfig).build();
+                    .builder().withScoreCalculationCountLimit(steps).build();
             final CounterfactualExplainer counterfactualExplainer =
                     CounterfactualExplainer
                             .builder(goal, constraints, dataDomain)
@@ -171,10 +168,8 @@ class CounterfactualExplainerTest {
             constraints.set(3, true);
             final DataDomain dataDomain = new DataDomain(featureBoundaries);
 
-            TerminationConfig stepTerminationConfig = new TerminationConfig();
-            stepTerminationConfig.setScoreCalculationCountLimit(steps);
             final SolverConfig solverConfig = CounterfactualConfigurationFactory
-                    .builder().withTerminationConfig(stepTerminationConfig).build();
+                    .builder().withScoreCalculationCountLimit(steps).build();
             final CounterfactualExplainer counterfactualExplainer =
                     CounterfactualExplainer
                             .builder(goal, constraints, dataDomain)
@@ -239,10 +234,8 @@ class CounterfactualExplainerTest {
             constraints.set(3, true);
             final DataDomain dataDomain = new DataDomain(featureBoundaries);
 
-            TerminationConfig stepTerminationConfig = new TerminationConfig();
-            stepTerminationConfig.setScoreCalculationCountLimit(steps);
             final SolverConfig solverConfig = CounterfactualConfigurationFactory
-                    .builder().withTerminationConfig(stepTerminationConfig).build();
+                    .builder().withScoreCalculationCountLimit(steps).build();
             final CounterfactualExplainer counterfactualExplainer =
                     CounterfactualExplainer
                             .builder(goal, constraints, dataDomain)
@@ -296,10 +289,8 @@ class CounterfactualExplainerTest {
             constraints.set(2, true);
             final DataDomain dataDomain = new DataDomain(featureBoundaries);
 
-            TerminationConfig stepTerminationConfig = new TerminationConfig();
-            stepTerminationConfig.setScoreCalculationCountLimit(steps);
             final SolverConfig solverConfig = CounterfactualConfigurationFactory
-                    .builder().withTerminationConfig(stepTerminationConfig).build();
+                    .builder().withScoreCalculationCountLimit(steps).build();
             final CounterfactualExplainer counterfactualExplainer =
                     CounterfactualExplainer
                             .builder(goal, constraints, dataDomain)
@@ -350,10 +341,8 @@ class CounterfactualExplainerTest {
             constraints.add(false);
             final DataDomain dataDomain = new DataDomain(featureBoundaries);
 
-            TerminationConfig stepTerminationConfig = new TerminationConfig();
-            stepTerminationConfig.setScoreCalculationCountLimit(steps);
             final SolverConfig solverConfig = CounterfactualConfigurationFactory
-                    .builder().withTerminationConfig(stepTerminationConfig).build();
+                    .builder().withScoreCalculationCountLimit(steps).build();
             final CounterfactualExplainer counterfactualExplainer =
                     CounterfactualExplainer
                             .builder(goal, constraints, dataDomain)

--- a/explainability/core/counterfactuals/src/test/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualExplainerTest.java
+++ b/explainability/core/counterfactuals/src/test/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualExplainerTest.java
@@ -15,12 +15,14 @@
  */
 package org.kie.kogito.explainability.local.counterfactual;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.kie.kogito.explainability.Config;
 import org.kie.kogito.explainability.TestUtils;
 import org.kie.kogito.explainability.local.counterfactual.entities.CounterfactualEntity;
 import org.kie.kogito.explainability.model.*;
 import org.optaplanner.core.config.solver.SolverConfig;
+import org.optaplanner.core.config.solver.termination.TerminationConfig;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -36,7 +38,8 @@ import static org.junit.jupiter.api.Assertions.*;
 class CounterfactualExplainerTest {
 
     final long predictionTimeOut = 10L;
-    final TimeUnit predictionTimeUnit = TimeUnit.SECONDS;
+    final TimeUnit predictionTimeUnit = TimeUnit.MINUTES;
+    final Long steps = 200_000L;
 
     @Test
     void testNonEmptyInput() throws ExecutionException, InterruptedException, TimeoutException {
@@ -56,8 +59,11 @@ class CounterfactualExplainerTest {
                 constraints.add(false);
             }
             final DataDomain dataDomain = new DataDomain(featureBoundaries);
+            TerminationConfig stepTerminationConfig = new TerminationConfig();
+            // for the purpose of this test, only a few steps are necessary
+            stepTerminationConfig.setScoreCalculationCountLimit(10L);
             final SolverConfig solverConfig = CounterfactualConfigurationFactory
-                    .createSolverConfig(1L, 70, 5000);
+                    .builder().withTerminationConfig(stepTerminationConfig).build();
             final CounterfactualExplainer counterfactualExplainer =
                     CounterfactualExplainer
                             .builder(goal, constraints, dataDomain)
@@ -105,8 +111,10 @@ class CounterfactualExplainerTest {
 
             final DataDomain dataDomain = new DataDomain(featureBoundaries);
 
+            TerminationConfig stepTerminationConfig = new TerminationConfig();
+            stepTerminationConfig.setScoreCalculationCountLimit(steps);
             final SolverConfig solverConfig = CounterfactualConfigurationFactory
-                    .createSolverConfig(1L, 70, 5000);
+                    .builder().withTerminationConfig(stepTerminationConfig).build();
             final CounterfactualExplainer counterfactualExplainer =
                     CounterfactualExplainer
                             .builder(goal, constraints, dataDomain)
@@ -163,8 +171,10 @@ class CounterfactualExplainerTest {
             constraints.set(3, true);
             final DataDomain dataDomain = new DataDomain(featureBoundaries);
 
+            TerminationConfig stepTerminationConfig = new TerminationConfig();
+            stepTerminationConfig.setScoreCalculationCountLimit(steps);
             final SolverConfig solverConfig = CounterfactualConfigurationFactory
-                    .createSolverConfig(5L, 70, 5000);
+                    .builder().withTerminationConfig(stepTerminationConfig).build();
             final CounterfactualExplainer counterfactualExplainer =
                     CounterfactualExplainer
                             .builder(goal, constraints, dataDomain)
@@ -228,8 +238,11 @@ class CounterfactualExplainerTest {
             constraints.set(0, true);
             constraints.set(3, true);
             final DataDomain dataDomain = new DataDomain(featureBoundaries);
+
+            TerminationConfig stepTerminationConfig = new TerminationConfig();
+            stepTerminationConfig.setScoreCalculationCountLimit(steps);
             final SolverConfig solverConfig = CounterfactualConfigurationFactory
-                    .createSolverConfig(5L, 70, 5000);
+                    .builder().withTerminationConfig(stepTerminationConfig).build();
             final CounterfactualExplainer counterfactualExplainer =
                     CounterfactualExplainer
                             .builder(goal, constraints, dataDomain)
@@ -283,8 +296,10 @@ class CounterfactualExplainerTest {
             constraints.set(2, true);
             final DataDomain dataDomain = new DataDomain(featureBoundaries);
 
+            TerminationConfig stepTerminationConfig = new TerminationConfig();
+            stepTerminationConfig.setScoreCalculationCountLimit(steps);
             final SolverConfig solverConfig = CounterfactualConfigurationFactory
-                    .createSolverConfig(5L, 70, 5000);
+                    .builder().withTerminationConfig(stepTerminationConfig).build();
             final CounterfactualExplainer counterfactualExplainer =
                     CounterfactualExplainer
                             .builder(goal, constraints, dataDomain)
@@ -335,8 +350,10 @@ class CounterfactualExplainerTest {
             constraints.add(false);
             final DataDomain dataDomain = new DataDomain(featureBoundaries);
 
+            TerminationConfig stepTerminationConfig = new TerminationConfig();
+            stepTerminationConfig.setScoreCalculationCountLimit(steps);
             final SolverConfig solverConfig = CounterfactualConfigurationFactory
-                    .createSolverConfig(5L, 70, 5000);
+                    .builder().withTerminationConfig(stepTerminationConfig).build();
             final CounterfactualExplainer counterfactualExplainer =
                     CounterfactualExplainer
                             .builder(goal, constraints, dataDomain)


### PR DESCRIPTION
In addition to the default search termination (with a time limit), allow to specify custom termination configurations for the counterfactual search.

In this PR a fixed number of score calculation steps is used for the unit tests.