### PR TITLE
[FAI-299] Implement minimum score threshold for counterfactuals

### DIFF
--- a/explainability/core/counterfactuals/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualExplainer.java
+++ b/explainability/core/counterfactuals/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualExplainer.java
@@ -141,7 +141,6 @@ public class CounterfactualExplainer implements LocalExplainer<List<Counterfactu
         private DataDistribution dataDistribution = null;
         private Executor executor = ForkJoinPool.commonPool();
         private SolverConfig solverConfig = null;
-        private double minimumPredictionScore = 0.0;
 
         private Builder(List<Output> goal, List<Boolean> constraints, DataDomain dataDomain) {
             this.goal = goal;
@@ -161,11 +160,6 @@ public class CounterfactualExplainer implements LocalExplainer<List<Counterfactu
 
         public Builder withSolverConfig(SolverConfig solverConfig) {
             this.solverConfig = solverConfig;
-            return this;
-        }
-
-        public Builder withMinimumPredictionScore(double minimumPredictionScore) {
-            this.minimumPredictionScore = minimumPredictionScore;
             return this;
         }
 

--- a/explainability/core/counterfactuals/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualExplainer.java
+++ b/explainability/core/counterfactuals/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualExplainer.java
@@ -54,6 +54,12 @@ public class CounterfactualExplainer implements LocalExplainer<List<Counterfactu
 
     /**
      * Create a new {@link CounterfactualExplainer} using OptaPlanner as the underlying engine.
+     * The data distribution information (if available) will be used to scale the features during the search.
+     * The bounds of the search space must be specified using a {@link DataDomain} and any feature constraints
+     * must be specified using a {@link List} of {@link Boolean}.
+     * The desired outcome is passed using an {@link Output}, where the score of each feature represents the
+     * minimum prediction score for a counterfactual to be considered.
+     * A customizable OptaPlanner solver configuration can be passed using a {@link SolverConfig}.
      *
      * @param dataDistribution Characteristics of the data distribution as {@link DataDistribution}, if available
      * @param dataDomain       A {@link DataDomain} which specifies the search space domain
@@ -135,6 +141,7 @@ public class CounterfactualExplainer implements LocalExplainer<List<Counterfactu
         private DataDistribution dataDistribution = null;
         private Executor executor = ForkJoinPool.commonPool();
         private SolverConfig solverConfig = null;
+        private double minimumPredictionScore = 0.0;
 
         private Builder(List<Output> goal, List<Boolean> constraints, DataDomain dataDomain) {
             this.goal = goal;
@@ -154,6 +161,11 @@ public class CounterfactualExplainer implements LocalExplainer<List<Counterfactu
 
         public Builder withSolverConfig(SolverConfig solverConfig) {
             this.solverConfig = solverConfig;
+            return this;
+        }
+
+        public Builder withMinimumPredictionScore(double minimumPredictionScore) {
+            this.minimumPredictionScore = minimumPredictionScore;
             return this;
         }
 

--- a/explainability/core/counterfactuals/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualSolution.java
+++ b/explainability/core/counterfactuals/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualSolution.java
@@ -56,7 +56,7 @@ public class CounterfactualSolution {
 
     }
 
-    @PlanningScore(bendableHardLevelsSize = 2, bendableSoftLevelsSize = 1)
+    @PlanningScore(bendableHardLevelsSize = 3, bendableSoftLevelsSize = 1)
     public BendableBigDecimalScore getScore() {
         return score;
     }

--- a/explainability/core/counterfactuals/src/test/java/org/kie/kogito/explainability/TestUtils.java
+++ b/explainability/core/counterfactuals/src/test/java/org/kie/kogito/explainability/TestUtils.java
@@ -100,13 +100,14 @@ public class TestUtils {
             List<PredictionOutput> predictionOutputs = new LinkedList<>();
             for (PredictionInput predictionInput : inputs) {
                 List<Feature> features = predictionInput.getFeatures();
+                final int N = features.size();
                 double result = 0;
-                for (int i = 0; i < features.size(); i++) {
+                for (int i = 0; i < N; i++) {
                         result += features.get(i).getValue().asNumber();
                 }
                 final boolean inside = (result >= center - epsilon && result <= center + epsilon);
                 PredictionOutput predictionOutput = new PredictionOutput(
-                        List.of(new Output("inside", Type.BOOLEAN, new Value<>(inside), 1d)));
+                        List.of(new Output("inside", Type.BOOLEAN, new Value<>(inside), 1.0 - Math.abs(result - center))));
                 predictionOutputs.add(predictionOutput);
             }
             return predictionOutputs;


### PR DESCRIPTION
Implement minimum counterfactual predictive score.

The minimum score is specified when building a `List<Output> goal` by specifying the `score` parameter.