### PR TITLE
[FAI-338] Score calculation support for multiple predictions

### DIFF
--- a/explainability/core/counterfactuals/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterFactualScoreCalculator.java
+++ b/explainability/core/counterfactuals/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterFactualScoreCalculator.java
@@ -72,32 +72,38 @@ public class CounterFactualScoreCalculator implements EasyScoreCalculator<Counte
 
         PredictionInput predictionInput = new PredictionInput(input);
 
-        List<PredictionInput> inputs = new ArrayList<>();
-        inputs.add(predictionInput);
+        List<PredictionInput> inputs = List.of(predictionInput);
+
         CompletableFuture<List<PredictionOutput>> predictionAsync = solution.getModel().predictAsync(inputs);
+
+        final List<Output> goal = solution.getGoal();
 
         try {
             List<PredictionOutput> predictions = predictionAsync.get();
 
-            final List<Output> outputs = predictions.get(0).getOutputs();
-            final List<Output> goal = solution.getGoal();
-
             double distance = 0.0;
-            if (outputs.size() != predictions.size()) {
-                throw new IllegalArgumentException("Prediction size must be equal to goal size");
-            }
-            for (int i = 0; i < outputs.size(); i++) {
-                final Output output = outputs.get(i);
-                final Output goalOutput = goal.get(i);
-                distance += goalOutput.getValue().asNumber() - output.getValue().asNumber();
-                if (output.getScore() < goalOutput.getScore()) {
-                    tertiaryHardScore -= 1;
+
+            for (PredictionOutput predictionOutput : predictions) {
+
+                final List<Output> outputs = predictionOutput.getOutputs();
+                
+                if (outputs.size() != predictions.size()) {
+                    throw new IllegalArgumentException("Prediction size must be equal to goal size");
                 }
+                for (int i = 0; i < outputs.size(); i++) {
+                    final Output output = outputs.get(i);
+                    final Output goalOutput = goal.get(i);
+                    distance += goalOutput.getValue().asNumber() - output.getValue().asNumber();
+                    if (output.getScore() < goalOutput.getScore()) {
+                        tertiaryHardScore -= 1;
+                    }
+                }
+                primaryHardScore -= distance * distance;
+                logger.debug("Penalise outcome (prediction distance: {})", primaryHardScore);
+                logger.debug("Penalise outcome (constraints changed: {})", secondaryHardScore);
+                logger.debug("Penalise outcome (confidence threshold: {})", tertiaryHardScore);
+
             }
-            primaryHardScore -= distance * distance;
-            logger.debug("Penalise outcome (prediction distance: {})", primaryHardScore);
-            logger.debug("Penalise outcome (constraints changed: {})", secondaryHardScore);
-            logger.debug("Penalise outcome (confidence threshold: {})", tertiaryHardScore);
 
         } catch (InterruptedException | ExecutionException e) {
             logger.error("Impossible to obtain prediction {}", e.getMessage());

--- a/explainability/core/counterfactuals/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterFactualScoreCalculator.java
+++ b/explainability/core/counterfactuals/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterFactualScoreCalculator.java
@@ -46,6 +46,15 @@ public class CounterFactualScoreCalculator implements EasyScoreCalculator<Counte
     private static final Logger logger =
             LoggerFactory.getLogger(CounterFactualScoreCalculator.class);
 
+    /**
+     * Calculates the counterfactual score for each proposed solution.
+     *
+     * This method assumes that each model used as {@link org.kie.kogito.explainability.model.PredictionProvider} is
+     * consistent, in the sense that for repeated operations, the size of the returned collection of
+     * {@link PredictionOutput} is the same, if the size of {@link PredictionInput} doesn't change.
+     * @param solution Proposed solution
+     * @return A {@link BendableBigDecimalScore} with three "hard" levels and one "soft" level
+     */
     @Override
     public BendableBigDecimalScore calculateScore(CounterfactualSolution solution) {
 
@@ -86,7 +95,7 @@ public class CounterFactualScoreCalculator implements EasyScoreCalculator<Counte
             for (PredictionOutput predictionOutput : predictions) {
 
                 final List<Output> outputs = predictionOutput.getOutputs();
-                
+
                 if (outputs.size() != predictions.size()) {
                     throw new IllegalArgumentException("Prediction size must be equal to goal size");
                 }


### PR DESCRIPTION
The counterfactual score calculation no longer assumes that a `PredictionProvider` result collection of `PredictionOutput`s contains a single element.
Instead, now if a `PredictionProvider` returns multiple results for a single input, its score is calculated from all responses.